### PR TITLE
Temp fix for module gitpages

### DIFF
--- a/core/ManagerUI/scripts/moduleManagement.tscript
+++ b/core/ManagerUI/scripts/moduleManagement.tscript
@@ -177,14 +177,18 @@ function pullUpdateModuleComplete(%resultCode)
 
 function openModuleGitPage(%buildIdx)
 {
-   %gitPath = getModuleGitPathByIndex(%buildIdx);
+   //Disabled until getModuleGitPathByIndex() function exists
+   //%gitPath = getModuleGitPathByIndex(%buildIdx);
+   %gitPath = %buildIdx.gitPath;
    
    gotoWebPage(%gitPath);
 }
 
 function openModuleIssuesPage(%buildIdx)
 {
-   %gitPath = getModuleGitPathByIndex(%buildIdx);
+   //Disabled until getModuleGitPathByIndex() function exists
+   //%gitPath = getModuleGitPathByIndex(%buildIdx);
+   %gitPath = %buildIdx.gitPath;
    
    gotoWebPage(%gitPath @ "/issues");
 }


### PR DESCRIPTION
Temporary fix for module git pages that works the same way as openEngineBuildGitPage() until getModuleGitPathByIndex() function exists